### PR TITLE
[LEOP-154]set cpu count by provide an env var from external to create correct workers number

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const createWorkers = () => {
   spinner.succeed(`${files.length} files found`);
   spinner.start(`Spawning workers...`);
 
-  const cpuCount = os.cpus().length;
+  const cpuCount = process.env.CPU_NUMBER || os.cpus().length;
   const workers = getWorkers(files, cpuCount);
 
   spinner.succeed(`${workers.length} workers spawned`);
@@ -136,7 +136,7 @@ const worker = () =>
 
               if (argv.prefixComment) {
                 try {
-                  const comment = `/* 
+                  const comment = `/*
 ${argv.prefixComment.replace(/^/gm, ' * ')}
 */`;
                   prefixedContents = [comment, result.css].join('\n');


### PR DESCRIPTION
We have observed that scripts that spin up worker processes use os.cpus.length() to determine the number of available CPU cores.
When this is used within a docker container, the os.cpus.length() returns the number of cpu cores the host has, not the container.
Hence many more workers are spawned (in our tests 43 workers when we have only 8 cores) which impacts performance. 
so we should set the CPU number as a static value when run in a docker container to avoid impacting our pipeline performance.

reference: LEOP-154
Doc: The impact to our pipeline by spinning up lots more workers than cpus