### PR TITLE
Updating npm version to match LTS/Node stable pairing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       },
       "engines": {
         "node": "^18.0.0",
-        "npm": "^9.0.0"
+        "npm": "^9.0.0 || ^10.2.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "engines": {
     "node": "^18.0.0",
-    "npm": "^9.0.0"
+    "npm": "^9.0.0 || ^10.2.5"
   },
   "scripts": {
     "test:lint": "npm run lint",


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing.
-->

The current Internal node stable version includes an update to npm 10.  Additionally, the .nvmrc file pins the LTS/hydrogen version - which too expects npm 10 as a pairing.

The change is backwards compatible and thus this should only be a minor bump.

Remember to include the following changes:

- [x] `CHANGELOG.md` (Add the type of change and description under `UNRELEASED` according to [Semver](https://semver.org)).
- [x] `README.md`
- [x] Tests

